### PR TITLE
Use library for finding config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
+## 0.6.0
+
+- Improve config loading & searching
+- Rename `suppress_header_output` to `display_cmd` and flipped the boolean logic
+
 ## 0.5.1
 
 - Fix bad command spliting in some cases
 - Less restrictive dependencies (compatible with Flutter stable)
-
-## 0.5.1
-
 - Use unlocked dependencies
 
 ## 0.5.0

--- a/README.md
+++ b/README.md
@@ -3,19 +3,6 @@
 A general script runner for any type of project - run all your project-related scripts and commands
 in a portable, simple config.
 
-<details>
-<summary>Table of contents</summary>
-
-- [What for?](#what-for)
-- [Features](#features)
-- [Getting started](#getting-started)
-- [Usage](#usage)
-  - [Normal usage (config file)](#normal-usage-config-file)
-  - [Advanced usage (Dart import)](#advanced-usage-dart-import)
-- [Contributing](#contributing)
-
-</details>
-
 ---
 
 ## What for?
@@ -68,6 +55,8 @@ would you?)
 Add the `script_runner` config to your `pubspec.yaml` under `script_runner`, or alternatively you
 can use a separate config file named `script_runner.yaml` at the root of your project.
 
+If you are using a separate file, you may also use JSON instead of YAML, if you prefer.
+
 A bare-bones example looks like this:
 
 ```yaml
@@ -104,7 +93,7 @@ script_runner:
   line_length: 80
   # Scripts support either a short-format config, or a more verbose one with
   # more possible argument to pass to each script.
-  # Scripts can reference other scripts, e.g. `script1` can reference
+  # Scripts are aliased for the current, e.g. `script1` can reference
   # `script2` by calling it directly in the command:
   # - script1: echo '1'
   # - name: script2
@@ -124,13 +113,15 @@ script_runner:
       env:
         MY_ENV: my-value
         # ...
-      # Use to suppress the "Running: ..." output before running the command
-      # to make it possible to use ouput for other scripts
-      suppress_header_output: true
+      # Use `false` to hide the command itself before running it.
+      # This is useful for using the output in other scripts (scr or external)
+      # Defaults to true
+      display_cmd: true
       # The script to run. You can supply the args directly here, or split into
       # `cmd` and `args` as a list.
       cmd: my_scr 'arg1'
-      # Optional - if supplied, will be appended as arguments to `cmd`.
+      # Optional - if supplied, will be appended as arguments to `cmd`, before the args passed
+      # by calling the script from the CLI
       args:
         - arg2
         - arg3
@@ -190,6 +181,6 @@ If you are a developer and want to contribute code, here are some starting tips:
 1. Fork this repository
 2. Run `dart pub get`
 3. Make any changes you would like
-4. Create tests for your changes
-5. Update the relevant documentation (readme, code comments)
+4. Create tests for your changes, run all tests to make sure no regressions are introduced
+5. Update the relevant documentation (readme, code comments, changelog)
 6. Create a PR on upstream

--- a/bin/script_runner.dart
+++ b/bin/script_runner.dart
@@ -3,11 +3,15 @@ import 'package:script_runner/src/utils.dart';
 
 /// Main entrypoint for CMD script runner.
 Future<void> main(List<String> args) async {
+  if (args.isEmpty) {
+    printColor('No script command provided. Use -h to see available commands.', [TerminalColor.red]);
+    return;
+  }
   final scriptCmd = args.first;
   final scriptArgs = args.sublist(1);
   try {
     await runScript(scriptCmd, scriptArgs);
-  } catch (e) {
-    printColor('$e', [TerminalColor.red]);
+  } catch (e, stack) {
+    printColor('$e\n$stack', [TerminalColor.red]);
   }
 }

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -82,7 +82,6 @@ class ScriptRunnerConfig {
     final source = sourceMap.values.first;
     final configSource = sourceMap.keys.first;
 
-
     final env = <String, String>{}..addAll(
         (source['env'] as Map?)?.cast<String, String>() ?? {},
       );
@@ -175,8 +174,7 @@ class ScriptRunnerConfig {
 
   static Future<Map<String, Map>> _tryFindConfig(
       FileSystem fs, String startDir) async {
-    final explorer =
-        Unaconfig('script_runner', fs: fs);
+    final explorer = Unaconfig('script_runner', fs: fs);
     final config = await explorer.search();
     if (config != null) {
       final source = await explorer.findConfig();
@@ -294,4 +292,3 @@ enum OS {
   linux,
   // other
 }
-

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -1,6 +1,5 @@
 library script_runner;
 
-import 'dart:convert';
 import 'dart:io';
 import 'dart:math' as math;
 
@@ -176,28 +175,6 @@ class ScriptRunnerConfig {
 
   static Future<Map<String, Map>> _tryFindConfig(
       FileSystem fs, String startDir) async {
-    // final defaultParsers = <ConfigParser>[
-    //   ConfigParser(
-    //     RegExp(r'^pubspec\.yaml$'),
-    //     (name, path, contents) {
-    //       final map = ConfigParser.loadYamlAsMap(contents);
-    //       if (map.containsKey(name)) {
-    //         print('name: $name, map: $map');
-    //         print('Returning map: ${map[name]}');
-    //         return map[name];
-    //       }
-    //       return null;
-    //     },
-    //   ),
-    //   ConfigParser(
-    //     RegExp(r'\.json$'),
-    //     (name, path, contents) => json.decode(contents),
-    //   ),
-    //   ConfigParser(
-    //     RegExp(r'\.ya?ml$'),
-    //     (name, path, contents) => ConfigParser.loadYamlAsMap(contents),
-    //   ),
-    // ];
     final explorer =
         Unaconfig('script_runner', fs: fs);
     final config = await explorer.search();

--- a/lib/src/runnable_script.dart
+++ b/lib/src/runnable_script.dart
@@ -201,4 +201,3 @@ class RunnableScript {
     }
   }
 }
-

--- a/lib/src/runnable_script.dart
+++ b/lib/src/runnable_script.dart
@@ -5,7 +5,6 @@ import 'package:file/local.dart';
 import 'package:script_runner/src/config.dart';
 // ignore: no_leading_underscores_for_library_prefixes
 import 'package:script_runner/src/utils.dart' as _utils;
-import 'package:yaml/yaml.dart' as yaml;
 
 /// A runnable script with pre-defined name, cmd and args. May be run using the `run` command and optionally
 /// supplying extra arguments to pass.
@@ -64,33 +63,20 @@ class RunnableScript {
     this.appendNewline = false,
   }) : _fileSystem = fileSystem ?? LocalFileSystem();
 
-  /// Generate a runnable script from a yaml loaded map as defined in the config.
-  factory RunnableScript.fromYamlMap(yaml.YamlMap map,
-      {FileSystem? fileSystem}) {
-    final out = <String, dynamic>{};
-
-    if (map['name'] == null && map.keys.length == 1) {
-      out['name'] = map.keys.first;
-      out['cmd'] = map.values.first;
-    } else {
-      out.addAll(map.cast<String, dynamic>());
-      out['args'] =
-          (map['args'] as yaml.YamlList?)?.map((e) => e.toString()).toList();
-      out['env'] = (map['env'] as yaml.YamlMap?)?.cast<String, String>();
-    }
-    try {
-      return RunnableScript.fromMap(out, fileSystem: fileSystem);
-    } catch (e) {
-      throw StateError(
-          'Failed to parse script, arguments: $map, $fileSystem. Error: $e');
-    }
-  }
-
   /// Generate a runnable script from a normal map as defined in the config.
   factory RunnableScript.fromMap(
     Map<String, dynamic> map, {
     FileSystem? fileSystem,
   }) {
+    if (map['name'] == null && map.keys.length == 1) {
+      map['name'] = map.keys.first;
+      map['cmd'] = map.values.first;
+    } else {
+      map.addAll(map.cast<String, dynamic>());
+      map['args'] =
+          (map['args'] as List?)?.map((e) => e.toString()).toList();
+      map['env'] = (map['env'] as Map?)?.cast<String, String>();
+    }
     final name = map['name'] as String;
     final rawCmd = map['cmd'] as String;
     final cmd = rawCmd;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,9 @@ environment:
 dependencies:
   file: ^7.0.0
   path: '>=1.8.0 <2.0.0'
+  unaconfig: ^0.1.3
+  # unaconfig:
+  #   path: ../unaconfig
   yaml: ^3.1.2
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: script_runner
 description: Run all your project-related scripts in a portable, simple config.
-version: 0.5.1
+version: 0.6.0
 homepage: https://casraf.dev/
 repository: https://github.com/chenasraf/dart_script_runner
 license: MIT

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
   unaconfig: ^0.1.3
   # unaconfig:
   #   path: ../unaconfig
-  yaml: ^3.1.2
 
 dev_dependencies:
   lints:

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -144,8 +144,13 @@ void main() {
 }
 
 Future<void> _writeCustomConf(FileSystem fs, [String? contents]) async {
-  final pubFile = fs.file(path.join(fs.currentDirectory.path, 'script_runner.yaml'));
+  final homeDir = fs.directory(Platform.environment['HOME']!);
+  homeDir.create(recursive: true);
+  fs.currentDirectory = homeDir;
+  final pubFile =
+      fs.file(path.join(fs.currentDirectory.path, 'script_runner.yaml'));
   pubFile.create(recursive: true);
+  print('writing custom conf to ${pubFile.path}');
   await pubFile.writeAsString(
     contents ??
         [
@@ -159,8 +164,12 @@ Future<void> _writeCustomConf(FileSystem fs, [String? contents]) async {
 }
 
 Future<void> _writePubspec(FileSystem fs, [String? contents]) async {
+  final homeDir = fs.directory(Platform.environment['HOME']!);
+  homeDir.create(recursive: true);
+  fs.currentDirectory = homeDir;
   final pubFile = fs.file(path.join(fs.currentDirectory.path, 'pubspec.yaml'));
   pubFile.create(recursive: true);
+  print('writing pubspec to ${pubFile.path}');
   await pubFile.writeAsString(
     contents ??
         [
@@ -173,3 +182,4 @@ Future<void> _writePubspec(FileSystem fs, [String? contents]) async {
         ].join('\n'),
   );
 }
+

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -182,4 +182,3 @@ Future<void> _writePubspec(FileSystem fs, [String? contents]) async {
         ].join('\n'),
   );
 }
-


### PR DESCRIPTION
This changes the codebase to implement [unaconfig](https://pub.dev/packages/unaconfig) for finding the configuration file

- Adds `.json` file format support
- Easier to add/update config locations in the future
- Limits searching the file up to the home directory, and does not try to access parent dirs